### PR TITLE
bug fixes etc. it works!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+    - "0.12"
+    - "0.10"
+services:
+    - rabbitmq

--- a/README.md
+++ b/README.md
@@ -3,14 +3,74 @@ seneca-rabbitmq-transport
 
 Seneca micro-services message transport over RabbitMQ messaging.
 
-## Support
+
+Seneca Rabbitmq Transport Plugin
+--------------------------------
+
+This plugin provides an rpc channel for micro-service messages using [rabbitmq](https://www.rabbitmq.com/)
+
+Example
+-------
+
+```js
+var seneca = require('seneca')()
+  .use('rabbitmq-transport')
+  .add('foo:two',function(args,done){ done(null,{bar:args.bar}) })
+  .client( {type:'rabbitmq',pin:'foo:one,bar:*'} )
+  .listen( {type:'rabbitmq',pin:'foo:two,bar:*'} )
+
+seneca.act("foo:two,bar:taco",function(error,data){
+  console.log(data);// prints {bar:taco}
+});
+
+```
+
+Details
+-------
+
+A single server from the pool of available servers will be given a message. and the response will be sent to the client who requested it. these messages are not persistant and do not expect acks with the default configuration.
+
+ALSO READ: The [seneca-transport](http://github.com/rjrodger/seneca-transport) readme has lots of introductory material about message transports. Start there if you have not used a message transport before.
+
+[![Build Status](https://travis-ci.org/rjrodger/seneca-transport.png?branch=master)](https://travis-ci.org/rjrodger/seneca-transport)
+
+For a gentle introduction to Seneca itself, see the
+[senecajs.org](http://senecajs.org) site.
+
+
+Install
+-------
+
+```sh
+npm install seneca-rabbitmq-transport
+```
+
+You'll also need [rabbitmq](https://www.rabbitmq.com/download.html).
+
+### ubuntu / apt-get
+
+```
+apt-get install rabbitmq-server
+```
+
+Testing
+-------
+tests are in mocha. run `npm test`
+
+there are some example scripts on the test directory as well as a performace test.
+
+to run the performance test `npm run test-perf` or `./tests/perf.js`. ill avoid posting my numbers here.
+
+
+Support
+-------
 
 If you're using this module, feel free to contact me on Twitter if you
 have any questions! :) [@rjrodger](http://twitter.com/rjrodger)
 
-Current Version: 0.2.1
+Current Version: 0.3.0
 
-Tested on: Node 0.10.31, Seneca 0.5.21
+Tested on: Node 0.12.0, Seneca 0.6.1
 
 
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ there are some example scripts on the test directory as well as a performace tes
 to run the performance test `npm run test-perf` or `./tests/perf.js`. ill avoid posting my numbers here.
 
 
+Issues
+------
+
+this transport will throw an exception of the rabbitmq connection goes away for any reason.
+
+
 Support
 -------
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ seneca-rabbitmq-transport
 
 Seneca micro-services message transport over RabbitMQ messaging.
 
+[![Build Status](https://travis-ci.org/soldair/seneca-rabbitmq-transport.png?branch=master)](https://travis-ci.org/rjrodger/seneca-rabbitmq-transport)
 
 Seneca Rabbitmq Transport Plugin
 --------------------------------
@@ -32,7 +33,6 @@ A single server from the pool of available servers will be given a message. and 
 
 ALSO READ: The [seneca-transport](http://github.com/rjrodger/seneca-transport) readme has lots of introductory material about message transports. Start there if you have not used a message transport before.
 
-[![Build Status](https://travis-ci.org/rjrodger/seneca-transport.png?branch=master)](https://travis-ci.org/rjrodger/seneca-transport)
 
 For a gentle introduction to Seneca itself, see the
 [senecajs.org](http://senecajs.org) site.

--- a/misc/purgerabbitmq.sh
+++ b/misc/purgerabbitmq.sh
@@ -1,0 +1,1 @@
+sudo rabbitmqctl stop_app && sudo rabbitmqctl reset && sudo rabbitmqctl start_app

--- a/misc/showqueues.sh
+++ b/misc/showqueues.sh
@@ -1,0 +1,1 @@
+sudo rabbitmqctl list_queues name messages_ready messages_unacknowledged

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Seneca RabbitMQ transport",
   "main": "rabbitmq-transport.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha test/*.test.js"
+    "test": "mocha test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "seneca-rabbitmq-transport",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Seneca RabbitMQ transport",
   "main": "rabbitmq-transport.js",
   "scripts": {
-    "test": "mocha test/*.test.js"
+    "test": "mocha test/*.test.js",
+    "test-perf":"./test/perf.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "async": "~0.9.0",
     "mocha": "~1.20.1",
-    "seneca": "~0.5.21",
+    "seneca": "~0.6.1",
     "seneca-salestax": "^0.1.3",
     "seneca-transport-test": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "amqplib": "~0.2.1",
+    "node-uuid": "^1.4.3",
     "underscore": "~1.7.0"
   },
   "peerDependencies": {
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "async": "~0.9.0",
+    "minimist": "^1.1.1",
     "mocha": "~1.20.1",
     "seneca": "~0.6.1",
     "seneca-salestax": "^0.1.3",

--- a/rabbitmq-transport.js
+++ b/rabbitmq-transport.js
@@ -54,6 +54,15 @@ module.exports = function( options ) {
     amqp.connect(listen_options.url, sock_options , function (error, connection) {
       if (error) return done(error)
 
+      // TODO
+      // this gets called whenever the conection to rabbit is closed.
+      // its real easy to reproduce with `sudo rabbitmqctl stop_app && sudo rabbitmqctl start_app`
+      // I need to reconnect here.
+      //
+      //connection.on('error',function(){
+      /// TODO !!
+      //})
+
       connection.createChannel(function (error, channel) {
         if (error) return done(error);
 
@@ -70,9 +79,6 @@ module.exports = function( options ) {
           channel.consume(acttopic, on_message,{noAck:true});
 
           function on_message ( message ) {
-
-
-            //console.log('[server] got rpc.',message.content.toString(),message.properties);
 
             var content = message.content ? message.content.toString() : undefined
             var data = tu.parseJSON( seneca, 'listen-'+type, content )

--- a/test/perf.js
+++ b/test/perf.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+var argv = require('minimist')(process.argv.slice(2));
+if(argv.h || argv.help){
+  console.log("USE: ");
+  console.log(" -n number of messages to send. (optional) default 1000");
+  console.log(" -c number of concurrent messages to send. (optional) default 1");
+  process.exit();
+}
+
+var cp = require('child_process');
+
+var client = cp.spawn(__dirname+"/perfclient.js",argv)
+
+client.stdout.pipe(process.stdout);
+client.stderr.pipe(process.stderr);
+
+var exit;
+var killed = false;
+client.on('exit',function(code){
+  if(killed) return;
+  if(code) {
+    process.stderr.write("client exited with code ",code);
+    exit = code;
+  }
+  killed = true;
+  server.kill();
+})
+
+// todo. more than one server.
+var server = cp.spawn("node",[__dirname+"/server.js"]);
+
+server.on('exit',function(code){
+  if(killed) return;
+  if(code){
+    process.stderr.write("client exited with code ",code);
+    exit = code;   
+  }
+  client.kill();
+})

--- a/test/perfclient.js
+++ b/test/perfclient.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+var argv = require('minimist')(process.argv.slice(2));
+if(argv.h || argv.help){
+  console.log("USE: ");
+  console.log(" -n number of messages to send. (optional) default 1000");
+  //console.log(" -c number of concurrent messages to process. (optional) default 1");
+  process.exit();
+}
+
+var seneca = require('seneca')()
+  .use('..')
+  .client({type:'rabbitmq'})
+
+var c = 0;
+var tries = argv.n||1000;
+var start;
+var samples = [];
+var sum = 0;
+
+var started = 0;
+var concur = 0;
+
+console.log('starting');
+//make one call to season things.
+seneca.act('foo:1,zed:10',function(err){
+  if(err) throw err;
+
+  start = Date.now();
+  var jobs = 1;//argv.c||1;
+  while(jobs--) {
+    console.log('started worker')
+    act();
+  }
+});
+
+function act(){
+  started++;
+  (function fn(skip){
+    if(++c === tries) return done();
+    var t = Date.now();
+    seneca.act('foo:1,zed:10',function(err){
+      if(!skip){
+        samples.push(Date.now()-t);
+        sum += samples[samples.length-1];
+      }
+      if(err) throw err;
+      fn();
+    });
+  })(true);
+}
+
+function done(){
+  var end = Date.now();
+  var elapsed = end-start;
+
+  if(!concur) concur = started;
+  if(--started) return;
+
+  var mean = sum/tries;
+  var max = 0, min = Infinity, dsum=0;
+  samples.forEach(function(v){
+    if(v < min) min = v;
+    if(v > max) max = v;
+    dsum += Math.pow(mean-v,2);
+  });
+
+  var stddev = Math.sqrt(dsum/tries);
+  var distribution = {};
+
+  samples.forEach(function(v){
+    absv = Math.abs(v-mean);
+
+    var dist = Math.floor(absv/stddev);
+    if(v < mean) dist = dist*-1;
+    if(!distribution[dist]) distribution[dist] = {c:0,ms:0};
+    distribution[dist].c++;
+    distribution[dist].ms += v;
+  });
+
+  Object.keys(distribution).forEach(function(k){
+    distribution[k]['%'] = +((distribution[k].c/tries*100)+'').substr(0,5);
+    distribution[k].ms_per = +((distribution[k].ms/distribution[k].c)+'').substr(0,5);
+  })
+
+  
+  
+  console.log("\nHI! you just ran a perf test!")
+  console.log("calls: "+tries);
+  console.log("time: "+elapsed);
+  console.log("ms/calls: "+elapsed/tries);
+  console.log("concurrency: "+concur);
+  console.log("slowest call: "+max);
+  console.log("fastest call: "+min);
+  console.log("stddev: "+stddev);
+  console.log("value distribution by deviations from the mean %:");
+  console.log(distribution);
+
+  seneca.close();
+}
+

--- a/test/rabbitmq-transport.test.js
+++ b/test/rabbitmq-transport.test.js
@@ -3,15 +3,14 @@
 
 var test = require('seneca-transport-test')
 
-
 describe('rabbitmq-transport', function() {
 
   it('happy-any', function( fin ) {
-    test.foo_test( 'rabbitmq-transport', require, fin, 'rabbitmq', -6379 )
+    test.foo_test( 'rabbitmq-transport', require, fin, 'rabbitmq', -5672 ) // default port is 5672 and tls 5673
   })
 
   it('happy-pin', function( fin ) {
-    test.foo_pintest( 'rabbitmq-transport', require, fin, 'rabbitmq', -6379 )
+    test.foo_pintest( 'rabbitmq-transport', require, fin, 'rabbitmq', -5672 )
   })
 
 })

--- a/test/salestax.test.js
+++ b/test/salestax.test.js
@@ -6,7 +6,7 @@ var async = require('async')
 
 
 var seneca = require('seneca')()
-  .use('rabbitmq-transport')
+  .use('..')
   .use('salestax', {
     country: {
       'FR': 0.20,


### PR DESCRIPTION

this changes how the lib uses rabbit to match their recommended rpc pattern, fixes message leaks, and allows more than one client to make calls and get responses. 

updates to tests and docs.

travis.
https://travis-ci.org/soldair/seneca-rabbitmq-transport

a performance test.
```
> npm run test-perf
....

HI! you just ran a perf test!
calls: 1000
time: 3158
ms/calls: 3.158
concurrency: 1
slowest call: 43
fastest call: 2
stddev: 2.11773324618564
value distribution by deviations from the mean %:
{ '0': { c: 956, ms: 2717, '%': 95.6, ms_per: 2.842 },
  '1': { c: 20, ms: 126, '%': 2, ms_per: 6.3 },
  '2': { c: 7, ms: 59, '%': 0.7, ms_per: 8.428 },
  '3': { c: 5, ms: 53, '%': 0.5, ms_per: 10.6 },
  '4': { c: 3, ms: 38, '%': 0.3, ms_per: 12.66 },
  '5': { c: 3, ms: 45, '%': 0.3, ms_per: 15 },
  '6': { c: 1, ms: 16, '%': 0.1, ms_per: 16 },
  '8': { c: 1, ms: 22, '%': 0.1, ms_per: 22 },
  '9': { c: 1, ms: 24, '%': 0.1, ms_per: 24 },
  '18': { c: 1, ms: 43, '%': 0.1, ms_per: 43 } }

```

this leaves one large issue that must be fixed. reconnecting to the broker when it gets disconnected. i left notes in the main file but i think this should be a second pull request because it will move quite a bit of code around to make it so i can call queue binding again without double calling seneca callbacks.
